### PR TITLE
Remove the § character from broadcast messages to prevent being kicked.

### DIFF
--- a/src/main/java/to/pabli/twitchchat/TwitchChatMod.java
+++ b/src/main/java/to/pabli/twitchchat/TwitchChatMod.java
@@ -54,6 +54,7 @@ public class TwitchChatMod implements ModInitializer {
     if (ModConfig.getConfig().isBroadcastEnabled()) {
       try {
         String plainTextMessage = ModConfig.getConfig().getBroadcastPrefix() + username + ": " + message;
+        plainTextMessage = sanitiseMessage(plainTextMessage);
         if (MinecraftClient.getInstance().player != null) {
           MinecraftClient.getInstance().player.sendChatMessage(plainTextMessage);
         }
@@ -67,6 +68,11 @@ public class TwitchChatMod implements ModInitializer {
           .append(messageBodyText), UUID.randomUUID());
     }
   }
+
+  private static String sanitiseMessage(String message) {
+    return message.replaceAll("§", "");
+  }
+
   public static void addNotification(MutableText message) {
     MinecraftClient.getInstance().inGameHud.addChatMessage(MessageType.CHAT, message.formatted(Formatting.DARK_GRAY), UUID.randomUUID());
   }


### PR DESCRIPTION
Currently if somebody in twitch chat sends the character `§` the person with the mod ends up being kicked from the server (including singleplayer) for sending illegal characters.

I made this lil patch for a friend but thought it might also be useful to PR back to you if you are interested. Its a bit of a quick fix and I don't know if other characters can also trigger it but this is a very rudimentary fix that does at least work.