### PR TITLE
update to fabric 1.19.4

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-	id 'fabric-loom' version '0.12-SNAPSHOT'
+	id 'fabric-loom' version '1.1-SNAPSHOT'
 	id 'maven-publish'
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,17 +3,17 @@ org.gradle.jvmargs=-Xmx1G
 
 # Fabric Properties
 	# check these on https://fabricmc.net/develop/
-	minecraft_version=1.19.3
-	yarn_mappings=1.19.3+build.5
-	loader_version=0.14.13
+	minecraft_version=1.19.4
+	yarn_mappings=1.19.4+build.1
+	loader_version=0.14.17
 
 # Mod Properties
-	mod_version=0.14.3b
+	mod_version=0.14.4b
 	maven_group=eu.pabl
 	archives_base_name=twitchchat
 
 # Dependencies
 	# currently not on the main fabric site, check on the maven: https://maven.fabricmc.net/net/fabricmc/fabric-api/fabric-api
-	fabric_version=0.73.0+1.19.3
-	cloth_config_version=9.0.94
-	mod_menu_version=5.0.2
+	fabric_version=0.76.0+1.19.4
+	cloth_config_version=10.0.96
+	mod_menu_version=6.1.0-rc.3

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -27,7 +27,7 @@
   ],
 
   "depends": {
-    "minecraft": ">=1.19.3",
+    "minecraft": ">=1.19.4",
     "fabricloader": ">=0.11.3",
     "fabric": "*",
     "modmenu": "*",


### PR DESCRIPTION
It was crashing due to Cloth Config API being outdated. Technically one can use `twitchchat-0.14.3b.jar` together with `cloth-config-10.0.96-fabric.jar` to make the current version work on 1.19.4 but this PR makes it trouble-free.