### PR TITLE
24-bit user colors

### DIFF
--- a/src/main/java/eu/pabl/twitchchat/TwitchChatMod.java
+++ b/src/main/java/eu/pabl/twitchchat/TwitchChatMod.java
@@ -11,6 +11,7 @@ import net.fabricmc.fabric.api.client.command.v2.ClientCommandRegistrationCallba
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.text.Text;
 import net.minecraft.text.MutableText;
+import net.minecraft.text.TextColor;
 import net.minecraft.util.Formatting;
 
 public class TwitchChatMod implements ModInitializer {
@@ -25,9 +26,9 @@ public class TwitchChatMod implements ModInitializer {
         new TwitchBaseCommand().registerCommands(dispatcher));
   }
 
-  public static void addTwitchMessage(String time, String username, String message, Formatting textColor, boolean isMeMessage) {
+  public static void addTwitchMessage(String time, String username, String message, TextColor textColor, boolean isMeMessage) {
     MutableText timestampText = Text.literal(time);
-    MutableText usernameText = Text.literal(username).formatted(textColor);
+    MutableText usernameText = Text.literal(username).styled(style -> style.withColor(textColor));
     MutableText messageBodyText;
 
     if (!isMeMessage) {
@@ -36,7 +37,7 @@ public class TwitchChatMod implements ModInitializer {
       // '/me' messages have the same color as the username in the Twitch website.
       // And thus I set the color of the message to be the same as the username.
       // They also don't have a colon after the username.
-      messageBodyText = Text.literal(" " + message).formatted(textColor);
+      messageBodyText = Text.literal(" " + message).styled(style -> style.withColor(textColor));
 
       // In Minecraft, a '/me' message is marked with a star before the name, like so:
       //

--- a/src/main/java/eu/pabl/twitchchat/mixin/ChatMixin.java
+++ b/src/main/java/eu/pabl/twitchchat/mixin/ChatMixin.java
@@ -8,7 +8,7 @@ import net.fabricmc.fabric.impl.client.indigo.IndigoMixinConfigPlugin;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.gui.screen.ChatScreen;
 import net.minecraft.text.Text;
-import net.minecraft.util.Formatting;
+import net.minecraft.text.TextColor;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
@@ -39,7 +39,7 @@ public class ChatMixin {
           String formattedTime = TwitchChatMod.formatDateTwitch(currentTime);
 
           String username = TwitchChatMod.bot.getUsername();
-          Formatting userColor;
+          TextColor userColor;
           if (TwitchChatMod.bot.isFormattingColorCached(username)) {
             userColor = TwitchChatMod.bot.getFormattingColor(username);
           } else {

--- a/src/main/java/eu/pabl/twitchchat/twitch_integration/Bot.java
+++ b/src/main/java/eu/pabl/twitchchat/twitch_integration/Bot.java
@@ -10,7 +10,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import javax.net.ssl.SSLSocketFactory;
 import net.minecraft.text.Text;
-import net.minecraft.util.Formatting;
+import net.minecraft.text.TextColor;
 import org.pircbotx.Channel;
 import org.pircbotx.Configuration;
 import org.pircbotx.PircBotX;
@@ -26,7 +26,7 @@ public class Bot extends ListenerAdapter {
   private final String username;
   private String channel;
   private ExecutorService myExecutor;
-  private HashMap<String, Formatting> formattingColorCache; // Map of usernames to colors to keep consistency with usernames and colors
+  private HashMap<String, TextColor> formattingColorCache; // Map of usernames to colors to keep consistency with usernames and colors
 
   public Bot(String username, String oauthKey, String channel) {
     this.channel = channel.toLowerCase();
@@ -90,7 +90,7 @@ public class Bot extends ListenerAdapter {
         String nick = user.getNick();
         if (!ModConfig.getConfig().getIgnoreList().contains(nick)) {
           String colorTag = v3Tags.get("color");
-          Formatting formattingColor;
+          TextColor formattingColor;
           
           if (isFormattingColorCached(nick)) {
             formattingColor = getFormattingColor(nick);
@@ -99,7 +99,7 @@ public class Bot extends ListenerAdapter {
               formattingColor = CalculateMinecraftColor.getDefaultUserColor(nick);
             } else {
               Color userColor = Color.decode(colorTag);
-              formattingColor = CalculateMinecraftColor.findNearestMinecraftColor(userColor);
+              formattingColor = TextColor.fromRgb(userColor.getRGB());
             }
             putFormattingColor(nick, formattingColor);
           }
@@ -151,7 +151,7 @@ public class Bot extends ListenerAdapter {
       if (!ModConfig.getConfig().getIgnoreList().contains(nick.toLowerCase())) {
         String formattedTime = TwitchChatMod.formatTMISentTimestamp(event.getTimestamp());
 
-        Formatting formattingColor;
+        TextColor formattingColor;
         if (isFormattingColorCached(nick)) {
           formattingColor = getFormattingColor(nick);
         } else {
@@ -193,10 +193,10 @@ public class Bot extends ListenerAdapter {
     return username;
   }
 
-  public void putFormattingColor(String nick, Formatting color) {
+  public void putFormattingColor(String nick, TextColor color) {
     formattingColorCache.put(nick.toLowerCase(), color);
   }
-  public Formatting getFormattingColor(String nick) {
+  public TextColor getFormattingColor(String nick) {
     return formattingColorCache.get(nick.toLowerCase());
   }
   public boolean isFormattingColorCached(String nick) {

--- a/src/main/java/eu/pabl/twitchchat/twitch_integration/CalculateMinecraftColor.java
+++ b/src/main/java/eu/pabl/twitchchat/twitch_integration/CalculateMinecraftColor.java
@@ -1,63 +1,17 @@
 package eu.pabl.twitchchat.twitch_integration;
 
-import java.awt.Color;
 import java.util.Arrays;
-import java.util.Comparator;
-import java.util.HashMap;
-import java.util.Map;
+import net.minecraft.text.TextColor;
 import net.minecraft.util.Formatting;
 
 public class CalculateMinecraftColor {
-  public static Formatting findNearestMinecraftColor(Color color) {
-    return Arrays.stream(Formatting.values())
-        .filter(Formatting::isColor)
-        .map(formatting -> {
-          Color formattingColor = new Color(formatting.getColorValue());
-
-          int distance = Math.abs(color.getRed() - formattingColor.getRed()) +
-              Math.abs(color.getGreen() - formattingColor.getGreen()) +
-              Math.abs(color.getBlue() - formattingColor.getBlue());
-          return new FormattingAndDistance(formatting, distance);
-        })
-        .sorted(Comparator.comparing(FormattingAndDistance::getDistance))
-        .map(FormattingAndDistance::getFormatting)
-        .findFirst()
-        .orElse(Formatting.WHITE);
-  }
-
-
-  public static final Formatting[] MINECRAFT_COLORS = Arrays.stream(Formatting.values()).filter(Formatting::isColor).toArray(Formatting[]::new);
+  public static final TextColor[] MINECRAFT_COLORS = Arrays.stream(Formatting.values()).filter(Formatting::isColor).map(TextColor::fromFormatting).toArray(TextColor[]::new);
   // Code gotten from here https://discuss.dev.twitch.tv/t/default-user-color-in-chat/385/2 but a little bit adjusted.
-  public static Map<String, Formatting> cachedNames = new HashMap<>();
-  public static Formatting getDefaultUserColor(String username) {
-    if (cachedNames.containsKey(username)) {
-      return cachedNames.get(username);
-    } else {
-      // If we don't have the color cached, calculate it.
-      char firstChar = username.charAt(0);
-      char lastChar = username.charAt(username.length() - 1);
+  public static TextColor getDefaultUserColor(String username) {
+    char firstChar = username.charAt(0);
+    char lastChar = username.charAt(username.length() - 1);
 
-      int n = ((int) firstChar) + ((int) lastChar);
-      return MINECRAFT_COLORS[n % MINECRAFT_COLORS.length];
-    }
-  }
-
-  private static class FormattingAndDistance {
-    private Formatting formatting;
-
-    public Formatting getFormatting() {
-      return formatting;
-    }
-
-    private int distance;
-
-    public int getDistance() {
-      return distance;
-    }
-
-    public FormattingAndDistance(Formatting formatting, int distance) {
-      this.formatting = formatting;
-      this.distance = distance;
-    }
+    int n = ((int) firstChar) + ((int) lastChar);
+    return MINECRAFT_COLORS[n % MINECRAFT_COLORS.length];
   }
 }

--- a/src/main/java/eu/pabl/twitchchat/twitch_integration/CalculateMinecraftColor.java
+++ b/src/main/java/eu/pabl/twitchchat/twitch_integration/CalculateMinecraftColor.java
@@ -1,17 +1,31 @@
 package eu.pabl.twitchchat.twitch_integration;
 
-import java.util.Arrays;
 import net.minecraft.text.TextColor;
-import net.minecraft.util.Formatting;
 
 public class CalculateMinecraftColor {
-  public static final TextColor[] MINECRAFT_COLORS = Arrays.stream(Formatting.values()).filter(Formatting::isColor).map(TextColor::fromFormatting).toArray(TextColor[]::new);
+  public static final TextColor[] DEFAULT_COLORS = new TextColor[]{
+          TextColor.fromRgb(0xFF0000),
+          TextColor.fromRgb(0x0000FF),
+          TextColor.fromRgb(0x00FF00),
+          TextColor.fromRgb(0xB22222),
+          TextColor.fromRgb(0xFF7F50),
+          TextColor.fromRgb(0x9ACD32),
+          TextColor.fromRgb(0xFF4500),
+          TextColor.fromRgb(0x2E8B57),
+          TextColor.fromRgb(0xDAA520),
+          TextColor.fromRgb(0xD2691E),
+          TextColor.fromRgb(0x5F9EA0),
+          TextColor.fromRgb(0x1E90FF),
+          TextColor.fromRgb(0xFF69B4),
+          TextColor.fromRgb(0x8A2BE2),
+          TextColor.fromRgb(0x00FF7F)
+  };
   // Code gotten from here https://discuss.dev.twitch.tv/t/default-user-color-in-chat/385/2 but a little bit adjusted.
   public static TextColor getDefaultUserColor(String username) {
     char firstChar = username.charAt(0);
     char lastChar = username.charAt(username.length() - 1);
 
     int n = ((int) firstChar) + ((int) lastChar);
-    return MINECRAFT_COLORS[n % MINECRAFT_COLORS.length];
+    return DEFAULT_COLORS[n % DEFAULT_COLORS.length];
   }
 }


### PR DESCRIPTION
Since Minecraft 1.16, chat messages support full 24-bit RGB color, instead of only the previous 16 predefined colors (`Formatting` class). This patch introduces the capability for the mod to take advantage of this feature and show messages from Twitch with the precise color instead of rounding it to the nearest predefined color.

Resolves #21 